### PR TITLE
Generate plain-text email report from scanner

### DIFF
--- a/essential-plugin-malware-scan/essential-plugin-scan.sh
+++ b/essential-plugin-malware-scan/essential-plugin-scan.sh
@@ -9,10 +9,13 @@
 #   - Flags wp-config.php infection (unusual file size or C2 domain references)
 #   - Broad C2 domain scan across all PHP files outside the plugins directory
 #   - Outputs a colour-coded report with per-site status and remediation steps
+#   - Generates a plain-text report file suitable for emailing to clients
 #   - Self-update capability with automatic or manual updates
 # Usage: ./essential-plugin-scan.sh [--update|--self-update]
 # Environment Variables:
 #   WP_VHOSTS_DIR         - Plesk vhosts root directory (default: /var/www/vhosts)
+#   REPORT_FILE           - Output path for the plain-text email report
+#                           (default: /tmp/essential-plugin-scan-<hostname>-<timestamp>.txt)
 #   AUTO_UPDATE           - Set to "true" to enable automatic updates (default: false)
 #   UPDATE_CHECK_INTERVAL - Hours between update checks (default: 24)
 #   GITHUB_BRANCH         - GitHub branch to update from (default: main)
@@ -165,6 +168,12 @@ fi
 # Directory containing Plesk virtual hosts
 WP_VHOSTS_DIR="${WP_VHOSTS_DIR:-/var/www/vhosts}"
 
+# Plain-text report file written alongside terminal output — ready to email to a client
+REPORT_FILE="${REPORT_FILE:-/tmp/essential-plugin-scan-$(hostname -s)-$(date '+%Y%m%d-%H%M%S').txt}"
+
+# Open file descriptor 3 for the report file
+exec 3>"${REPORT_FILE}"
+
 # All 31 plugin slugs permanently closed by WordPress.org on April 7, 2026.
 # The entire "Essential Plugin" portfolio was acquired via Flippa in early 2025
 # and backdoored in version 2.6.7 (August 8, 2025), then weaponised April 5-6, 2026.
@@ -221,10 +230,17 @@ SITES_COMPROMISED=0
 # FUNCTIONS
 ###############################################################################
 
-log_info()   { echo -e "${CYAN}[INFO]${NC}   $1"; }
-log_ok()     { echo -e "${GREEN}[OK]${NC}     $1"; }
-log_warn()   { echo -e "${YELLOW}[WARN]${NC}   $1"; }
-log_danger() { echo -e "${RED}[DANGER]${NC} $1"; }
+# Output helpers — write to terminal (with colours) and to fd 3 / report file (plain text)
+rpt()          { echo "$*";                              echo "$*" >&3; }
+section()      { echo -e "${BOLD}$1${NC}";              echo "$1" >&3; }
+status_danger(){ echo -e "  ${RED}${BOLD}$1${NC}";      echo "  $1" >&3; }
+status_warn()  { echo -e "  ${YELLOW}${BOLD}$1${NC}";   echo "  $1" >&3; }
+status_ok()    { echo -e "  ${GREEN}$1${NC}";           echo "  $1" >&3; }
+
+log_info()   { echo -e "${CYAN}[INFO]${NC}   $1"; echo "[INFO]   $1" >&3; }
+log_ok()     { echo -e "${GREEN}[OK]${NC}     $1"; echo "[OK]     $1" >&3; }
+log_warn()   { echo -e "${YELLOW}[WARN]${NC}   $1"; echo "[WARN]   $1" >&3; }
+log_danger() { echo -e "${RED}[DANGER]${NC} $1"; echo "[DANGER] $1" >&3; }
 
 # Check wp-config.php for signs of active infection.
 # Returns 0 = clean, 1 = signs of infection detected.
@@ -280,7 +296,7 @@ scan_signatures_in_dir() {
         if [ -n "${matches}" ]; then
             log_danger "  Backdoor signature '${sig}' found:"
             while IFS= read -r f; do
-                echo "    -> ${f}"
+                echo "    -> ${f}"; echo "    -> ${f}" >&3
             done <<< "${matches}"
         fi
     done
@@ -299,8 +315,8 @@ scan_wordpress_site() {
 
     SITES_SCANNED=$((SITES_SCANNED + 1))
 
-    echo ""
-    echo -e "${BOLD}=== ${site_dir} ===${NC}"
+    rpt ""
+    section "=== ${site_dir} ==="
 
     # --- 1. Check for affected plugin slugs ---
     local found_count=0
@@ -349,7 +365,7 @@ scan_wordpress_site() {
         | grep -v "/wp-content/plugins/" || true)
     if [ -n "${c2_hits}" ]; then
         log_danger "  C2 domain reference found outside the plugins directory:"
-        while IFS= read -r f; do echo "    -> ${f}"; done <<< "${c2_hits}"
+        while IFS= read -r f; do echo "    -> ${f}"; echo "    -> ${f}" >&3; done <<< "${c2_hits}"
         site_is_compromised=1
     fi
 
@@ -366,23 +382,23 @@ scan_wordpress_site() {
 
     # --- Per-site status verdict ---
     if [ "${site_is_compromised}" -eq 1 ]; then
-        echo -e "  ${RED}${BOLD}STATUS: ACTIVELY COMPROMISED${NC}"
-        echo "  Remediation:"
-        echo "    1. Restore wp-config.php from a clean backup (pre-April 6, 2026)"
-        echo "    2. Delete wp-comments-posts.php if present"
-        echo "    3. Remove or replace all affected plugins"
-        echo "    4. Rotate all database passwords and WordPress secret keys"
-        echo "    5. Audit all PHP files for additional injected payloads"
-        echo "    6. Check Google Search Console for hidden SEO spam / cloaked redirects"
+        status_danger "STATUS: ACTIVELY COMPROMISED"
+        rpt "  Remediation:"
+        rpt "    1. Restore wp-config.php from a clean backup (pre-April 6, 2026)"
+        rpt "    2. Delete wp-comments-posts.php if present"
+        rpt "    3. Remove or replace all affected plugins"
+        rpt "    4. Rotate all database passwords and WordPress secret keys"
+        rpt "    5. Audit all PHP files for additional injected payloads"
+        rpt "    6. Check Google Search Console for hidden SEO spam / cloaked redirects"
     elif [ "${site_has_backdoor}" -eq 1 ]; then
-        echo -e "  ${YELLOW}${BOLD}STATUS: BACKDOOR PRESENT (may not yet have been activated)${NC}"
-        echo "  Remediation: Remove wpos-analytics/ from each affected plugin, or install patched versions."
-        echo "  Patched plugins: https://anchor.host/someone-bought-30-wordpress-plugins-and-planted-a-backdoor-in-all-of-them/"
+        status_warn "STATUS: BACKDOOR PRESENT (may not yet have been activated)"
+        rpt "  Remediation: Remove wpos-analytics/ from each affected plugin, or install patched versions."
+        rpt "  Patched plugins: https://anchor.host/someone-bought-30-wordpress-plugins-and-planted-a-backdoor-in-all-of-them/"
     elif [ "${site_has_plugin}" -eq 1 ]; then
-        echo -e "  ${YELLOW}${BOLD}STATUS: AFFECTED PLUGIN DETECTED (appears already cleaned/patched)${NC}"
-        echo "  Remediation: Confirm plugin is on version 2.6.9.1+ and consider full removal."
+        status_warn "STATUS: AFFECTED PLUGIN DETECTED (appears already cleaned/patched)"
+        rpt "  Remediation: Confirm plugin is on version 2.6.9.1+ and consider full removal."
     else
-        echo -e "  ${GREEN}STATUS: CLEAN${NC}"
+        status_ok "STATUS: CLEAN"
     fi
 
     return 0
@@ -392,24 +408,29 @@ scan_wordpress_site() {
 # MAIN
 ###############################################################################
 
-echo ""
-echo -e "${BOLD}================================================================${NC}"
-echo -e "${BOLD}  Essential Plugin Supply-Chain Attack Scanner                  ${NC}"
-echo -e "${BOLD}  Threat: WordPress plugins weaponized via Flippa acquisition   ${NC}"
-echo -e "${BOLD}  Attack activated: April 5-6, 2026 (backdoor planted Aug 2025) ${NC}"
-echo -e "${BOLD}  IOC domain: analytics.essentialplugin.com                     ${NC}"
-echo -e "${BOLD}  Scan started: $(date '+%Y-%m-%d %H:%M:%S %Z')                       ${NC}"
-echo -e "${BOLD}================================================================${NC}"
-echo ""
+SCAN_STARTED="$(date '+%Y-%m-%d %H:%M:%S %Z')"
+SERVER_HOST="$(hostname)"
+
+rpt ""
+section "================================================================"
+section "  Essential Plugin Supply-Chain Attack Scanner"
+section "  Threat: WordPress plugins weaponized via Flippa acquisition"
+section "  Attack activated: April 5-6, 2026 (backdoor planted Aug 2025)"
+section "  IOC domain: analytics.essentialplugin.com"
+section "  Server: ${SERVER_HOST}"
+section "  Scan started: ${SCAN_STARTED}"
+section "================================================================"
+rpt ""
 
 if [ ! -d "${WP_VHOSTS_DIR}" ]; then
-    echo "ERROR: Vhosts directory '${WP_VHOSTS_DIR}' not found."
-    echo "       Set the WP_VHOSTS_DIR environment variable to override."
+    rpt "ERROR: Vhosts directory '${WP_VHOSTS_DIR}' not found."
+    rpt "       Set the WP_VHOSTS_DIR environment variable to override."
+    exec 3>&-
     exit 1
 fi
 
-echo "Scanning: ${WP_VHOSTS_DIR}"
-echo "Checking for ${#AFFECTED_PLUGINS[@]} known affected plugin slugs..."
+rpt "Scanning: ${WP_VHOSTS_DIR}"
+rpt "Checking for ${#AFFECTED_PLUGINS[@]} known affected plugin slugs..."
 
 # Find all WordPress installations, excluding system and cache directories
 while IFS= read -r wp_config; do
@@ -428,53 +449,60 @@ done < <(
 # SUMMARY REPORT
 ###############################################################################
 
-echo ""
-echo -e "${BOLD}================================================================${NC}"
-echo -e "${BOLD}  SCAN COMPLETE — SUMMARY                                       ${NC}"
-echo -e "${BOLD}================================================================${NC}"
-echo "  WordPress sites scanned        : ${SITES_SCANNED}"
-echo "  Sites with affected plugin(s)  : ${SITES_WITH_PLUGINS}"
-echo "  Sites with backdoor module     : ${SITES_WITH_BACKDOOR}"
-echo "  Sites actively compromised     : ${SITES_COMPROMISED}"
-echo ""
+rpt ""
+section "================================================================"
+section "  SCAN COMPLETE — SUMMARY"
+section "================================================================"
+rpt "  WordPress sites scanned        : ${SITES_SCANNED}"
+rpt "  Sites with affected plugin(s)  : ${SITES_WITH_PLUGINS}"
+rpt "  Sites with backdoor module     : ${SITES_WITH_BACKDOOR}"
+rpt "  Sites actively compromised     : ${SITES_COMPROMISED}"
+rpt ""
 
 if [ "${SITES_COMPROMISED}" -gt 0 ]; then
-    echo -e "${RED}${BOLD}CRITICAL: ${SITES_COMPROMISED} site(s) actively compromised — immediate action required!${NC}"
-    echo ""
-    echo "  Full remediation steps:"
-    echo "  1. Restore wp-config.php from a clean backup predating April 6, 2026"
-    echo "  2. Delete wp-comments-posts.php (the malware dropper) if present"
-    echo "  3. Remove or replace all Essential Plugin portfolio plugins"
-    echo "  4. Rotate all database passwords and WordPress secret keys"
-    echo "  5. Scan all PHP files for additional injected payloads"
-    echo "  6. Review Google Search Console for hidden SEO spam / cloaked redirects"
-    echo ""
+    status_danger "CRITICAL: ${SITES_COMPROMISED} site(s) actively compromised — immediate action required!"
+    rpt ""
+    rpt "  Full remediation steps:"
+    rpt "  1. Restore wp-config.php from a clean backup predating April 6, 2026"
+    rpt "  2. Delete wp-comments-posts.php (the malware dropper) if present"
+    rpt "  3. Remove or replace all Essential Plugin portfolio plugins"
+    rpt "  4. Rotate all database passwords and WordPress secret keys"
+    rpt "  5. Scan all PHP files for additional injected payloads"
+    rpt "  6. Review Google Search Console for hidden SEO spam / cloaked redirects"
+    rpt ""
 elif [ "${SITES_WITH_BACKDOOR}" -gt 0 ]; then
-    echo -e "${YELLOW}${BOLD}WARNING: ${SITES_WITH_BACKDOOR} site(s) have the backdoor module present.${NC}"
-    echo ""
-    echo "  Remediation options (for each affected plugin):"
-    echo "  Option A — Install a community-patched version (wpos-analytics stripped):"
-    echo "    wp plugin install https://plugins.captaincore.io/<plugin>-patched.zip --force"
-    echo ""
-    echo "  Option B — Manual removal:"
-    echo "    1. Delete wp-content/plugins/<plugin>/wpos-analytics/"
-    echo "    2. Remove the loader block from the main plugin PHP file"
-    echo "       (search for 'Plugin Wpos Analytics Data Starts' or 'wpos_analytics_anl')"
-    echo ""
-    echo "  Option C — Remove the plugin entirely if it is no longer needed"
-    echo ""
+    status_warn "WARNING: ${SITES_WITH_BACKDOOR} site(s) have the backdoor module present."
+    rpt ""
+    rpt "  Remediation options (for each affected plugin):"
+    rpt "  Option A — Install a community-patched version (wpos-analytics stripped):"
+    rpt "    wp plugin install https://plugins.captaincore.io/<plugin>-patched.zip --force"
+    rpt ""
+    rpt "  Option B — Manual removal:"
+    rpt "    1. Delete wp-content/plugins/<plugin>/wpos-analytics/"
+    rpt "    2. Remove the loader block from the main plugin PHP file"
+    rpt "       (search for 'Plugin Wpos Analytics Data Starts' or 'wpos_analytics_anl')"
+    rpt ""
+    rpt "  Option C — Remove the plugin entirely if it is no longer needed"
+    rpt ""
 elif [ "${SITES_WITH_PLUGINS}" -gt 0 ]; then
-    echo -e "${YELLOW}${BOLD}INFO: ${SITES_WITH_PLUGINS} site(s) had affected plugins (appear already patched).${NC}"
-    echo "  Verify each is on version 2.6.9.1+ and consider full removal."
-    echo ""
+    status_warn "INFO: ${SITES_WITH_PLUGINS} site(s) had affected plugins (appear already patched)."
+    rpt "  Verify each is on version 2.6.9.1+ and consider full removal."
+    rpt ""
 fi
 
 if [ "${SITES_SCANNED}" -eq 0 ]; then
-    echo "  No WordPress installations found under ${WP_VHOSTS_DIR}"
+    rpt "  No WordPress installations found under ${WP_VHOSTS_DIR}"
 elif [ "${SITES_WITH_PLUGINS}" -eq 0 ]; then
-    echo -e "${GREEN}${BOLD}All ${SITES_SCANNED} site(s) are CLEAN — no affected plugins detected.${NC}"
-    echo ""
+    status_ok "All ${SITES_SCANNED} site(s) are CLEAN — no affected plugins detected."
+    rpt ""
 fi
 
-echo "  Reference: https://anchor.host/someone-bought-30-wordpress-plugins-and-planted-a-backdoor-in-all-of-them/"
-echo ""
+rpt "  Reference: https://anchor.host/someone-bought-30-wordpress-plugins-and-planted-a-backdoor-in-all-of-them/"
+rpt ""
+
+# Write report footer and close the report file
+echo "Report generated: $(date '+%Y-%m-%d %H:%M:%S %Z') | Server: ${SERVER_HOST}" >&3
+exec 3>&-
+
+echo "Report saved to: ${REPORT_FILE}"
+echo "(You can email this file directly to your client)"


### PR DESCRIPTION
This pull request enhances the `essential-plugin-scan.sh` script by adding support for generating a plain-text report file suitable for emailing to clients, in addition to the existing color-coded terminal output. The script now logs all key output to both the terminal and a report file, ensuring that scan results and remediation steps are easily shareable. Several helper functions were refactored to streamline dual output, and all status and summary sections were updated to use the new reporting mechanism.

**New report output feature:**

* Added a `REPORT_FILE` environment variable (with a sensible default) to specify the output path for the plain-text report, and opened a dedicated file descriptor for writing report content. [[1]](diffhunk://#diff-75b6e23bb908e4d86764432c83cb4b045a00a201568b2401339a1a3fb28aeacfR12-R18) [[2]](diffhunk://#diff-75b6e23bb908e4d86764432c83cb4b045a00a201568b2401339a1a3fb28aeacfR171-R176)
* All major output (scan status, findings, and remediation steps) is now written both to the terminal (with color) and to the report file (plain text), using new helper functions (`rpt`, `section`, `status_danger`, `status_warn`, `status_ok`). [[1]](diffhunk://#diff-75b6e23bb908e4d86764432c83cb4b045a00a201568b2401339a1a3fb28aeacfL224-R243) [[2]](diffhunk://#diff-75b6e23bb908e4d86764432c83cb4b045a00a201568b2401339a1a3fb28aeacfL302-R319) [[3]](diffhunk://#diff-75b6e23bb908e4d86764432c83cb4b045a00a201568b2401339a1a3fb28aeacfL369-R401) [[4]](diffhunk://#diff-75b6e23bb908e4d86764432c83cb4b045a00a201568b2401339a1a3fb28aeacfL395-R433) [[5]](diffhunk://#diff-75b6e23bb908e4d86764432c83cb4b045a00a201568b2401339a1a3fb28aeacfL431-R508)

**Refactoring for dual output:**

* Updated all logging and status output throughout the script to use the new helper functions, ensuring consistency between terminal and report file outputs. [[1]](diffhunk://#diff-75b6e23bb908e4d86764432c83cb4b045a00a201568b2401339a1a3fb28aeacfL283-R299) [[2]](diffhunk://#diff-75b6e23bb908e4d86764432c83cb4b045a00a201568b2401339a1a3fb28aeacfL352-R368) [[3]](diffhunk://#diff-75b6e23bb908e4d86764432c83cb4b045a00a201568b2401339a1a3fb28aeacfL369-R401) [[4]](diffhunk://#diff-75b6e23bb908e4d86764432c83cb4b045a00a201568b2401339a1a3fb28aeacfL395-R433) [[5]](diffhunk://#diff-75b6e23bb908e4d86764432c83cb4b045a00a201568b2401339a1a3fb28aeacfL431-R508)

**User experience improvements:**

* The script now prints the location of the generated report file at the end of the scan, making it easy for users to find and share the results. [[1]](diffhunk://#diff-75b6e23bb908e4d86764432c83cb4b045a00a201568b2401339a1a3fb28aeacfL395-R433) [[2]](diffhunk://#diff-75b6e23bb908e4d86764432c83cb4b045a00a201568b2401339a1a3fb28aeacfL431-R508)
* Documentation and usage comments were updated to reflect the new report file feature and environment variable.

These changes make it much easier to share scan results with clients and improve the clarity and professionalism of the output.