### PR TITLE
Prefer SMTP_SERVER over local mail command for email reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ pci-dss-scan\pci-dss-scan.bat https://example.com
 - `DRY_RUN` - Set to `true` to enable dry-run mode (default: `false`)
   - Example: `DRY_RUN=true` previews deletions without removing files
 - `EMAIL_TO` - Email address to receive the per-domain report (default: unset, no email sent)
-  - Uses the local `mail` command if available; falls back to the SMTP relay settings below via `curl` if not
+  - If `SMTP_SERVER` is set, sends directly via `curl` (bypassing the local `mail` command entirely); otherwise falls back to the local `mail` command
   - Report includes, per domain: backups found, backups removed (or would-remove in dry-run), and filenames removed
 - `EMAIL_SUBJECT` - Subject line for the email report (default: `WordPress Backup Cleanup Report - <hostname>`)
 - `SMTP_SERVER` - SMTP relay hostname, used only if the local `mail` command is unavailable (default: unset)

--- a/remove-old-wordpress-backups/remove-wordpress-backups.sh
+++ b/remove-old-wordpress-backups/remove-wordpress-backups.sh
@@ -333,9 +333,10 @@ send_via_smtp() {
     return "${rc}"
 }
 
-# Function to email the report when EMAIL_TO is configured. Prefers the local
-# 'mail' command; falls back to a direct SMTP relay via curl when no local
-# MTA is present but SMTP_SERVER is configured.
+# Function to email the report when EMAIL_TO is configured. If SMTP_SERVER is
+# explicitly set, it takes priority (sends directly via curl) so an explicit
+# relay config always wins over a possibly-misconfigured local MTA. Falls
+# back to the local 'mail' command otherwise.
 send_email_report() {
     local body="$1"
 
@@ -343,21 +344,21 @@ send_email_report() {
 
     local subject="${EMAIL_SUBJECT:-WordPress Backup Cleanup Report - $(hostname -s 2>/dev/null || hostname)}"
 
-    if command -v mail >/dev/null 2>&1; then
-        if echo "${body}" | mail -s "${subject}" "${EMAIL_TO}"; then
-            log_message "Report emailed to ${EMAIL_TO}"
-            return 0
-        fi
-        log_message "WARNING: 'mail' command failed to send report to ${EMAIL_TO}"
-        return 1
-    fi
-
     if [ -n "${SMTP_SERVER}" ]; then
         if send_via_smtp "${subject}" "${body}"; then
             log_message "Report emailed to ${EMAIL_TO} via SMTP (${SMTP_SERVER}:${SMTP_PORT})"
             return 0
         fi
         log_message "WARNING: Failed to send email report to ${EMAIL_TO} via SMTP (${SMTP_SERVER}:${SMTP_PORT})"
+        return 1
+    fi
+
+    if command -v mail >/dev/null 2>&1; then
+        if echo "${body}" | mail -s "${subject}" "${EMAIL_TO}"; then
+            log_message "Report emailed to ${EMAIL_TO}"
+            return 0
+        fi
+        log_message "WARNING: 'mail' command failed to send report to ${EMAIL_TO}"
         return 1
     fi
 


### PR DESCRIPTION
## Summary
Fixes a case reported after merging #20: on a server with a local `mail`
command configured via `msmtp`, authentication was failing (`CRAM-MD5`
rejected by the relay), even though the user had also configured
`SMTP_SERVER`/`SMTP_AUTH_USER`/etc. for this script's SMTP fallback.

Root cause: `send_email_report` always tried the local `mail` command
first and only used the SMTP/curl path if `mail` was missing entirely — so
a misconfigured local MTA blocked delivery even with a working relay
configured explicitly for this script.

## Change
If `SMTP_SERVER` is set, send directly via `curl` (bypassing `mail`
entirely). Otherwise fall back to the local `mail` command as before.

## Testing
- `shellcheck` clean (pre-existing intentional-glob info only).
- Stubbed both `mail` (forced failure) and `curl` to confirm `SMTP_SERVER`
  now takes priority and `mail` is never invoked when it's set.
- README updated to describe the new precedence.