### PR TITLE
Add EMAIL_ONLY_ON_DELETIONS option to WordPress backup cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,7 @@ pci-dss-scan\pci-dss-scan.bat https://example.com
   - Sent as an HTML email. If `SMTP_SERVER` is set, sends directly via `curl` (bypassing the local `mail` command entirely); otherwise falls back to the local `mail` command
   - Report includes a summary (with total disk space), backups removed (or would-remove in dry-run) per domain with filenames, dates and sizes, and a backups-found table per domain with newest/oldest backup dates and disk space used
 - `EMAIL_SUBJECT` - Subject line for the email report (default: `WordPress Backup Cleanup Report - <hostname>`)
+- `EMAIL_ONLY_ON_DELETIONS` - Set to `true` to only send the email when at least one backup was actually deleted, skipping the report on runs where nothing was eligible (default: `false`)
 - `SMTP_SERVER` - SMTP relay hostname; when set, takes priority over the local `mail` command (default: unset)
 - `SMTP_PORT` - SMTP relay port (default: `25`)
 - `SMTP_AUTH_USER` / `SMTP_AUTH_PASS` - SMTP credentials, leave unset for an unauthenticated relay (default: unset)

--- a/remove-old-wordpress-backups/remove-wordpress-backups.sh
+++ b/remove-old-wordpress-backups/remove-wordpress-backups.sh
@@ -19,6 +19,7 @@
 #   MIN_KEEP - Minimum number of most recent backups to keep per domain (default: 3)
 #   DRY_RUN - Set to "true" to enable dry-run mode (default: false)
 #   EMAIL_TO - Email address to send the per-domain report to (default: unset, no email sent)
+#   EMAIL_ONLY_ON_DELETIONS - Set to "true" to only email when backups were actually deleted (default: false)
 #   EMAIL_SUBJECT - Subject line for the email report (default: "WordPress Backup Cleanup Report - <hostname>")
 #   SMTP_SERVER - SMTP relay host, used via curl if local 'mail' command is unavailable (default: unset)
 #   SMTP_PORT - SMTP relay port (default: 25)
@@ -187,6 +188,7 @@ FIND_CMD="/bin/find"
 RM_CMD="/bin/rm"
 EMAIL_TO="${EMAIL_TO:-}"
 EMAIL_SUBJECT="${EMAIL_SUBJECT:-}"
+EMAIL_ONLY_ON_DELETIONS="${EMAIL_ONLY_ON_DELETIONS:-false}"
 # SMTP fallback for servers without a local MTA (used only if 'mail' command is unavailable)
 SMTP_SERVER="${SMTP_SERVER:-}"
 SMTP_PORT="${SMTP_PORT:-25}"
@@ -543,7 +545,9 @@ remove_wordpress_backups() {
         log_message "No eligible backup files found. Nothing to delete."
         echo ""
         echo "${report}"
-        send_email_report "${html_report}"
+        if [ "${EMAIL_ONLY_ON_DELETIONS}" != "true" ]; then
+            send_email_report "${html_report}"
+        fi
         return 0
     fi
     


### PR DESCRIPTION
## Summary
Adds an `EMAIL_ONLY_ON_DELETIONS` environment variable to `remove-wordpress-backups.sh` so the email report is only sent when at least one backup was actually deleted. Skips the report when nothing was eligible, avoiding daily noise from runs that just show "0 backups removed". Dry-run and failure emails are unaffected — those still need eyes on them.

## Usage
```bash
EMAIL_ONLY_ON_DELETIONS=true EMAIL_TO="admin@example.com" ./remove-old-wordpress-backups/remove-wordpress-backups.sh
```

Default is `false` (unchanged behavior — email sent on every run when `EMAIL_TO` is set).